### PR TITLE
Fix find_official_image()

### DIFF
--- a/lib/common
+++ b/lib/common
@@ -25,7 +25,7 @@ coreos_image() {
 find_official_image() {
   local pattern="$1"
 
-  brightbox -s images list -t official 2>/dev/null | awk "/[[:space:]]${pattern}/ "'{print $1}'
+  brightbox -s images list -t official 2>/dev/null | awk "/${pattern}/ "'{print $1}'
 }
 
 # Create the build image server


### PR DESCRIPTION
Thanks for providing these tools.

I was trying to run `flynn/build-cluster`, however it was failing with an error message:

> Failed to locate trusty base image

I'd open an issue about it but you don't seem to have issues enabled, so I'm offering this PR as a potential fix, and we can discuss it here instead.
